### PR TITLE
Issue #23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,11 +135,7 @@ try:
           'command-line to reveal/complete command-line args. This currently '
           'only works on some operating systems (mainly Linux based).')
 
-    if not os.path.isdir(os.path.expanduser('~/.bash_completion')):
-
-        os.mkdir(os.path.expanduser('~/.bash_completion'))
-
-    BASHFILE = open(os.path.expanduser('~/.bash_completion/longbow'), 'w+')
+    BASHFILE = open(os.path.expanduser('~/.longbow/bash_completion'), 'w+')
 
     BASHFILE.write('_longbow()\n')
     BASHFILE.write('{\n')
@@ -158,6 +154,16 @@ try:
     BASHFILE.write('complete -F _longbow longbow"\n')
 
     BASHFILE.close()
+
+    # Now add a source entry to the user .bashrc
+    if os.path.isfile(os.path.expanduser('~/.bashrc')):
+
+        BASHFILE = open(os.path.expanduser('~/.bashrc'), 'a+')
+
+        if not any('source ~/.longbow/bash_completion'
+                   in bashline for bashline in BASHFILE.readlines()):
+
+            BASHFILE.write('source ~/.longbow/bash_completion')
 
 except IOError:
 


### PR DESCRIPTION
A file is now created inside the ~/.longbow directory in which the code
for the bash autocomplete is placed. An entry is then placed at the end
of the user bash profile to source this file. In future if it is
possible to provide uninstall scripts for pip (or if it is already) then
this can be removed upon uninstall.