### PR TITLE
Issue #63

### DIFF
--- a/longbow/corelibs/configuration.py
+++ b/longbow/corelibs/configuration.py
@@ -438,10 +438,18 @@ def _processconfigsfinalinit(jobs):
 
         jobs[job]["executableargs"] = jobs[job]["executableargs"].split()
 
-        # If modules hasn't been set then try and use a default.
+        # If modules hasn't been set then try and use a default. If the
+        # executable is given as an absolute path than we will assume the user
+        # knows they need to provide any modules to load etc.
         if jobs[job]["modules"] is "":
 
-            jobs[job]["modules"] = modules[jobs[job]["executable"]]
+            try:
+
+                jobs[job]["modules"] = modules[jobs[job]["executable"]]
+
+            except KeyError:
+
+                pass
 
         # Give each job a unique base path by adding a random hash to jobname.
         destdir = job + ''.join(["%s" % randint(0, 9) for _ in range(0, 5)])

--- a/tests/unit/corelibs_configuration/test_processconfigsfinalinit.py
+++ b/tests/unit/corelibs_configuration/test_processconfigsfinalinit.py
@@ -41,6 +41,7 @@ from longbow.corelibs.configuration import _processconfigsfinalinit
 def test_processconfigsfinalinit1():
 
     """
+    Tests for basic functionality of the final initialisation checking method.
     """
 
     jobs = {
@@ -75,3 +76,29 @@ def test_processconfigsfinalinit1():
     assert jobs["jobtwo"]["destdir"] != ""
     assert jobs["jobtwo"]["remoteworkdir"] == "/work/dir"
     assert jobs["jobtwo"]["modules"] == "gromacs"
+
+
+def test_processconfigsfinalinit2():
+
+    """
+    Test with an absolute path for the executable.
+    """
+
+    jobs = {
+        "test": {
+            "modules": "",
+            "localworkdir": "/somepath/to/dir",
+            "executableargs": "arg1 arg2 arg3",
+            "executable": "/some/path/to/mdrun_mpi_d",
+            "remoteworkdir": "/work/dir"
+        }
+    }
+
+    _processconfigsfinalinit(jobs)
+
+    assert jobs["test"]["localworkdir"] == "/somepath/to/dir"
+    assert jobs["test"]["executableargs"] == ["arg1", "arg2", "arg3"]
+    assert jobs["test"]["executable"] == "/some/path/to/mdrun_mpi_d"
+    assert jobs["test"]["destdir"] != ""
+    assert jobs["test"]["remoteworkdir"] == "/work/dir"
+    assert jobs["test"]["modules"] == ""


### PR DESCRIPTION
Fix for keyerror when no modules are given with an absolute path to a
self compiled executable. Longbow will assume the user knows what they
are doing if they are able to compile software. If modules are required
such as intel etc then these should be given by the user in a job config
file.

This should have also fixed a related but slightly different and
unreported bug with the use of environment variables. Had a user given
an executable that didn't have a longbow plugin (ie a generic one) along
with no modules, this would also have given an error, even though they
might have configured the HPC user account with environment vars.