### PR TITLE
Add LAMMPs intel executable

### DIFF
--- a/longbow/apps/lammps.py
+++ b/longbow/apps/lammps.py
@@ -70,7 +70,7 @@ EXECDATA = {
     },
     "lmp_intel_cpu_intelmpi": {
         "subexecutables": [],
-        "requiredfiles": ["-i"],
+        "requiredfiles": ["-in"],
     }
 }
 

--- a/longbow/apps/lammps.py
+++ b/longbow/apps/lammps.py
@@ -67,6 +67,10 @@ EXECDATA = {
     "lmp": {
         "subexecutables": [],
         "requiredfiles": ["-i"],
+    },
+    "lmp_intel_cpu_intelmpi": {
+        "subexecutables": [],
+        "requiredfiles": ["-i"],
     }
 }
 

--- a/longbow/apps/lammps.py
+++ b/longbow/apps/lammps.py
@@ -70,7 +70,7 @@ EXECDATA = {
     },
     "lmp_intel_cpu_intelmpi": {
         "subexecutables": [],
-        "requiredfiles": ["-in"],
+        "requiredfiles": ["-i"],
     }
 }
 

--- a/longbow/apps/lammps.py
+++ b/longbow/apps/lammps.py
@@ -46,31 +46,31 @@ import longbow.corelibs.exceptions as exceptions
 EXECDATA = {
     "lmp_xc30": {
         "subexecutables": [],
-        "requiredfiles": ["-i"],
+        "requiredfiles": ["-i || -in"],
     },
     "lmp_linux": {
         "subexecutables": [],
-        "requiredfiles": ["-i"],
+        "requiredfiles": ["-i || -in"],
     },
     "lmp_gpu": {
         "subexecutables": [],
-        "requiredfiles": ["-i"],
+        "requiredfiles": ["-i || -in"],
     },
     "lmp_mpi": {
         "subexecutables": [],
-        "requiredfiles": ["-i"],
+        "requiredfiles": ["-i || -in"],
     },
     "lmp_cuda": {
         "subexecutables": [],
-        "requiredfiles": ["-i"],
+        "requiredfiles": ["-i || -in"],
     },
     "lmp": {
         "subexecutables": [],
-        "requiredfiles": ["-i"],
+        "requiredfiles": ["-i || -in"],
     },
     "lmp_intel_cpu_intelmpi": {
         "subexecutables": [],
-        "requiredfiles": ["-in"],
+        "requiredfiles": ["-i || -in"],
     }
 }
 


### PR DESCRIPTION
I added support for the `lmp_intel_cpu_intelmpi` executable used on my local cluster by modifying `EXECDATA` inside `longbow/apps/lammps.py`.

For some reason, I had to use the `-in` argument rather than `-i`. Note that `-in` is the version used in the LAMMPs documentation, e.g. [here](http://lammps.sandia.gov/doc/Section_start.html#start-5).

I ran a simple test, and it worked.

========

Thank you very much for developing this software! I look forward to further integrating it into my LAMMPs workflow.