### PR TITLE
#77 Using pre-existing queue scripts

### DIFF
--- a/longbow/configuration.py
+++ b/longbow/configuration.py
@@ -109,6 +109,7 @@ JOBTEMPLATE = {
     "staging-frequency": "300",
     "sge-peflag": "mpi",
     "sge-peoverride": "false",
+    "subfile": "",
     "user": "",
     "upload-exclude": "",
     "upload-include": ""

--- a/longbow/scheduling.py
+++ b/longbow/scheduling.py
@@ -317,11 +317,18 @@ def prepare(jobs):
 
         try:
 
-            LOG.info("Creating submit file for job '%s'", item)
+            if job["subfile"] == "":
 
-            getattr(schedulers, scheduler.lower()).prepare(job)
+                LOG.info("Creating submit file for job '%s'", item)
 
-            LOG.info("Submit file created successfully")
+                getattr(schedulers, scheduler.lower()).prepare(job)
+
+                LOG.info("Submit file created successfully")
+
+            else:
+
+                LOG.info("For job '%s' user has supplied their own job submit "
+                         "script - skipping creation.", item)
 
         except AttributeError:
 

--- a/tests/unit/configuration/test_processconfigsresource.py
+++ b/tests/unit/configuration/test_processconfigsresource.py
@@ -131,6 +131,7 @@ def test_processconfigsresource1():
             "resource": "host1",
             "replicates": "1",
             "scheduler": "",
+            "subfile": "",
             "user": "",
             "upload-exclude": "",
             "upload-include": ""
@@ -237,6 +238,7 @@ def test_processconfigsresource2():
             "resource": "host2",
             "replicates": "1",
             "scheduler": "",
+            "subfile": "",
             "user": "",
             "upload-exclude": "",
             "upload-include": ""
@@ -344,6 +346,7 @@ def test_processconfigsresource3():
             "resource": "host1",
             "replicates": "1",
             "scheduler": "",
+            "subfile": "",
             "user": "",
             "upload-exclude": "",
             "upload-include": ""
@@ -450,6 +453,7 @@ def test_processconfigsresource4():
             "resource": "host3",
             "replicates": "1",
             "scheduler": "",
+            "subfile": "",
             "user": "",
             "upload-exclude": "",
             "upload-include": ""

--- a/tests/unit/scheduling/test_prepare.py
+++ b/tests/unit/scheduling/test_prepare.py
@@ -60,7 +60,8 @@ def test_prepare_single(mock_prepare):
         "job-one": {
             "resource": "test-machine",
             "scheduler": "LSF",
-            "jobid": "test456"
+            "jobid": "test456",
+            "subfile": ""
         }
     }
 
@@ -82,17 +83,20 @@ def test_prepare_multiple(mock_prepare):
         "job-one": {
             "resource": "test-machine",
             "scheduler": "LSF",
-            "jobid": "test123"
+            "jobid": "test123",
+            "subfile": ""
         },
         "job-two": {
             "resource": "test-machine",
             "scheduler": "LSF",
-            "jobid": "test456"
+            "jobid": "test456",
+            "subfile": ""
         },
         "job-three": {
             "resource": "test-machine",
             "scheduler": "LSF",
-            "jobid": "test789"
+            "jobid": "test789",
+            "subfile": ""
         }
     }
 
@@ -113,7 +117,8 @@ def test_prepare_attrexcept(mock_prepare):
         "job-one": {
             "resource": "test-machine",
             "scheduler": "LSF",
-            "jobid": "test456"
+            "jobid": "test456",
+            "subfile": ""
         }
     }
 
@@ -122,3 +127,25 @@ def test_prepare_attrexcept(mock_prepare):
     with pytest.raises(exceptions.PluginattributeError):
 
         prepare(jobs)
+
+
+@mock.patch('longbow.schedulers.lsf.prepare')
+def test_prepare_ownscript(mock_prepare):
+
+    """
+    Test that if user supplies a script that longbow doesn't create one.
+    """
+
+    jobs = {
+        "job-one": {
+            "resource": "test-machine",
+            "scheduler": "LSF",
+            "jobid": "test456",
+            "subfile": "test.lsf"
+        }
+    }
+
+    prepare(jobs)
+
+    assert mock_prepare.call_count == 0, \
+        "This method shouldn't be called at all in this case."


### PR DESCRIPTION
Users that set "subfile" in their configuration scripts can supply
pre-existing job submit files. Longbow will use this instead of creating
one. This is for advanced users that understand the implications of
doing this.

Closes #77