### PR TITLE
Update scheduling.py

### DIFF
--- a/longbow/scheduling.py
+++ b/longbow/scheduling.py
@@ -330,6 +330,8 @@ def prepare(jobs):
                 LOG.info("For job '%s' user has supplied their own job submit "
                          "script - skipping creation.", item)
 
+                job["upload-include"] = job["upload-include"] + ", " + job["subfile"]
+
         except AttributeError:
 
             raise exceptions.PluginattributeError(

--- a/tests/unit/scheduling/test_prepare.py
+++ b/tests/unit/scheduling/test_prepare.py
@@ -142,6 +142,7 @@ def test_prepare_ownscript(mock_prepare):
             "scheduler": "LSF",
             "jobid": "test456",
             "subfile": "test.lsf"
+            "upload-include": "file1, file2, file3"
         }
     }
 
@@ -149,3 +150,4 @@ def test_prepare_ownscript(mock_prepare):
 
     assert mock_prepare.call_count == 0, \
         "This method shouldn't be called at all in this case."
+    assert jobs["upload-include"] == "file1, file2, file3, test.lsf"

--- a/tests/unit/scheduling/test_prepare.py
+++ b/tests/unit/scheduling/test_prepare.py
@@ -141,7 +141,7 @@ def test_prepare_ownscript(mock_prepare):
             "resource": "test-machine",
             "scheduler": "LSF",
             "jobid": "test456",
-            "subfile": "test.lsf"
+            "subfile": "test.lsf",
             "upload-include": "file1, file2, file3"
         }
     }

--- a/tests/unit/scheduling/test_prepare.py
+++ b/tests/unit/scheduling/test_prepare.py
@@ -150,4 +150,4 @@ def test_prepare_ownscript(mock_prepare):
 
     assert mock_prepare.call_count == 0, \
         "This method shouldn't be called at all in this case."
-    assert jobs["upload-include"] == "file1, file2, file3, test.lsf"
+    assert jobs["job-one"]["upload-include"] == "file1, file2, file3, test.lsf"


### PR DESCRIPTION
Fix for missing job script transfer when using own submit files. Relates to a previously added feature in this release.