### PR TITLE
Renamed loggers #121

### DIFF
--- a/longbow/applications.py
+++ b/longbow/applications.py
@@ -57,7 +57,7 @@ import longbow.shellwrappers as shellwrappers
 import longbow.apps as apps
 
 
-LOG = logging.getLogger("longbow.corelibs.applications")
+LOG = logging.getLogger("longbow.applications")
 
 
 def checkapp(jobs):

--- a/longbow/configuration.py
+++ b/longbow/configuration.py
@@ -75,7 +75,7 @@ import longbow.exceptions as exceptions
 import longbow.apps as apps
 
 
-LOG = logging.getLogger("longbow.corelibs.configuration")
+LOG = logging.getLogger("longbow.configuration")
 
 JOBTEMPLATE = {
     "account": "",

--- a/longbow/scheduling.py
+++ b/longbow/scheduling.py
@@ -72,7 +72,7 @@ import longbow.staging as staging
 import longbow.schedulers as schedulers
 
 
-LOG = logging.getLogger("longbow.corelibs.scheduling")
+LOG = logging.getLogger("longbow.scheduling")
 
 
 def checkenv(jobs, hostconf):

--- a/longbow/shellwrappers.py
+++ b/longbow/shellwrappers.py
@@ -98,7 +98,7 @@ import time
 
 import longbow.exceptions as exceptions
 
-LOG = logging.getLogger("longbow.corelibs.shellwrappers")
+LOG = logging.getLogger("longbow.shellwrappers")
 
 
 def checkconnections(jobs):

--- a/longbow/staging.py
+++ b/longbow/staging.py
@@ -63,7 +63,7 @@ import os
 import longbow.exceptions as exceptions
 import longbow.shellwrappers as shellwrappers
 
-LOG = logging.getLogger("longbow.corelibs.staging")
+LOG = logging.getLogger("longbow.staging")
 
 
 def stage_upstream(jobs):


### PR DESCRIPTION
Some loggers had not been renamed after a prior code refactor. This has
now been fixed.

closes #121 